### PR TITLE
Do not publish `.babelrc`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+/.babelrc


### PR DESCRIPTION
- adds `.babelrc` to `.npmignore`
- this prevents the issue where projects that use `redux-multi` and `babel`
  would error because the transpiling of `redux-multi` would start and
  sometimes error

(ref https://github.com/ashaffer/redux-multi/issues/8)