### PR TITLE
Add '.babelrc' to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src
+.babelrc


### PR DESCRIPTION
react-native projects use Babel 6 and the current .babelrc 
in version 0.1.12 published on npm is incompatible with Babel 6.

The babelrc file for an npm module should  not be in the npm 
package at all, since transpilation should be done before publishing 
to npm, so we add .babelrc file to the npmignore file.

See similar issue in redux-thunk for more details
  https://github.com/gaearon/redux-thunk/issues/43